### PR TITLE
Fixing another crash when the host process dies

### DIFF
--- a/XAMLTest.Tests/TestRecorderTests.cs
+++ b/XAMLTest.Tests/TestRecorderTests.cs
@@ -78,6 +78,17 @@ namespace XamlTest.Tests
             await app.InitializeWithDefaults(null!);
         }
 
+        [TestMethod]
+        public async Task TestRecord_WithInvalidXAML_DoesNotRethrow()
+        {
+            await using var app = App.StartRemote();
+            await using (TestRecorder testRecorder = new(app))
+            {
+                await app.InitializeWithDefaults();
+                var ex = await Assert.ThrowsExceptionAsync<XAMLTestException>(async () => await app.CreateWindowWithContent("<InvalidContent />"));
+            }
+        }
+
         private static int GetLineNumber(int offset = 0, [CallerLineNumber] int lineNumber = 0)
             => lineNumber + offset;
     }

--- a/XAMLTest/TestRecorder.cs
+++ b/XAMLTest/TestRecorder.cs
@@ -79,11 +79,15 @@ namespace XamlTest
             string fullPath = Path.Combine(Directory, fileName);
             File.Delete(fullPath);
 
-            if (await App.GetScreenshot() is IImage screenshot)
+            try
             {
-                await screenshot.Save(fullPath);
-                return fullPath;
+                if (await App.GetScreenshot() is IImage screenshot)
+                {
+                    await screenshot.Save(fullPath);
+                    return fullPath;
+                }
             }
+            catch (XAMLTestException) { }
             return null;
         }
 


### PR DESCRIPTION
This prevents TestRecorder from crashing when attempting to save a screenshot of a crashed process.

Additional fix for #46 