### PR TITLE
Support for timeout message prefix

### DIFF
--- a/XAMLTest.Tests/WaitTests.cs
+++ b/XAMLTest.Tests/WaitTests.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace XamlTest.Tests
+{
+    [TestClass]
+    public class WaitTests
+    {
+        private Task<bool> Timeout()
+        {
+            return Task.FromResult(false);
+        }
+
+        private Task<bool> Success()
+        {
+            return Task.FromResult(true);
+        }
+
+        [TestMethod]
+        public async Task ShouldTimeout()
+        {
+            await Assert.ThrowsExceptionAsync<TimeoutException>(async () => await Wait.For(Timeout));
+        }
+
+        [TestMethod]
+        public async Task ShouldNotTimeout()
+        {
+            await Wait.For(Success);
+        }
+
+        [TestMethod]
+        public async Task ShouldTimeoutWithMessage()
+        {
+            var timeoutMessage = "We're expecting a timeout";
+            var ex = await Assert.ThrowsExceptionAsync<TimeoutException>(async () => await Wait.For(Timeout, message: timeoutMessage));
+            Assert.IsTrue(ex.Message.StartsWith(timeoutMessage), $"Expected exception message to start with: '{timeoutMessage}'");
+           
+        }
+    }
+}

--- a/XAMLTest/Wait.cs
+++ b/XAMLTest/Wait.cs
@@ -6,7 +6,7 @@ namespace XamlTest
 {
     public static class Wait
     {
-        public static async Task For(Func<Task<bool>> action, Retry? retry = null)
+        public static async Task For(Func<Task<bool>> action, Retry? retry = null, string? message = null)
         {
             if (action is null)
             {
@@ -45,23 +45,24 @@ namespace XamlTest
                 }
             }
             while (ShouldRetry());
-            throw new TimeoutException($"Timeout of '{retry}' exceeded", thrownException);
+            var prefix = message == null ? string.Empty : $"{message}. ";
+            throw new TimeoutException($"{prefix}Timeout of '{retry}' exceeded", thrownException);
 
             bool ShouldRetry() =>
                 sw.Elapsed <= retry.Timeout ||
                 numAttempts < retry.MinAttempts;
         }
 
-        public static async Task For(Func<Task> action, Retry? retry = null)
+        public static async Task For(Func<Task> action, Retry? retry = null, string? message = null)
         {
             await For(async () =>
             {
                 await action();
                 return true;
-            }, retry);
+            }, retry, message);
         }
 
-        public static async Task<T> For<T>(Func<Task<T>> action, Retry? retry = null)
+        public static async Task<T> For<T>(Func<Task<T>> action, Retry? retry = null, string? message = null)
             where T : class
         {
             T? rv = default;
@@ -69,7 +70,7 @@ namespace XamlTest
             {
                 rv = await action();
                 return true;
-            }, retry);
+            }, retry, message);
 
             return rv ?? throw new XAMLTestException("Return value is null");
         }


### PR DESCRIPTION
This is a PR for #50. I think this covers the description of #50 along with a few simple tests.