### PR TITLE
Allow disabling debugger attach

### DIFF
--- a/XAMLTest/App.cs
+++ b/XAMLTest/App.cs
@@ -6,62 +6,63 @@ using GrpcDotNetNamedPipes;
 using XamlTest.Host;
 using XamlTest.Internal;
 
-namespace XamlTest
+namespace XamlTest;
+
+public static class App
 {
-    public static class App
+    public static IApp StartRemote<TApp>(
+        string? xamlTestPath = null,
+        Action<string>? logMessage = null,
+        bool allowDebuggerAttach = true)
     {
-        public static IApp StartRemote<TApp>(
-            string? xamlTestPath = null,
-            Action<string>? logMessage = null)
+        string location = typeof(TApp).Assembly.Location;
+        return StartRemote(location, xamlTestPath, logMessage, allowDebuggerAttach);
+    }
+
+    public static IApp StartRemote(
+        string? remoteApp = null,
+        string ? xamlTestPath = null,
+        Action<string>? logMessage = null,
+        bool allowDebuggerAttach = true)
+    {
+        xamlTestPath ??= Path.ChangeExtension(Assembly.GetExecutingAssembly().Location, ".exe");
+        xamlTestPath = Path.GetFullPath(xamlTestPath);
+        if (!File.Exists(xamlTestPath))
         {
-            string location = typeof(TApp).Assembly.Location;
-            return StartRemote(location, xamlTestPath, logMessage);
+            throw new XAMLTestException($"Could not find test app '{xamlTestPath}'");
         }
 
-        public static IApp StartRemote(
-            string? remoteApp = null,
-            string ? xamlTestPath = null, 
-            Action<string>? logMessage = null)
+        ProcessStartInfo startInfo = new(xamlTestPath)
         {
-            xamlTestPath ??= Path.ChangeExtension(Assembly.GetExecutingAssembly().Location, ".exe");
-            xamlTestPath = Path.GetFullPath(xamlTestPath);
-            if (!File.Exists(xamlTestPath))
-            {
-                throw new XAMLTestException($"Could not find test app '{xamlTestPath}'");
-            }
+            WorkingDirectory = Path.GetDirectoryName(xamlTestPath) + Path.DirectorySeparatorChar,
+            UseShellExecute = true
+        };
+        startInfo.ArgumentList.Add($"{Process.GetCurrentProcess().Id}");
+        if (!string.IsNullOrWhiteSpace(remoteApp))
+        {
+            startInfo.ArgumentList.Add("--application-path");
+            startInfo.ArgumentList.Add(remoteApp);
+        }
+        bool useDebugger = allowDebuggerAttach && Debugger.IsAttached;
+        if (useDebugger)
+        {
+            startInfo.ArgumentList.Add($"--debug");
+        }
 
-            ProcessStartInfo startInfo = new(xamlTestPath)
+        if (Process.Start(startInfo) is Process process)
+        {
+            NamedPipeChannel channel = new(".", Server.PipePrefix + process.Id, new NamedPipeChannelOptions
             {
-                WorkingDirectory = Path.GetDirectoryName(xamlTestPath) + Path.DirectorySeparatorChar,
-                UseShellExecute = true
-            };
-            startInfo.ArgumentList.Add($"{Process.GetCurrentProcess().Id}");
-            if (!string.IsNullOrWhiteSpace(remoteApp))
-            {
-                startInfo.ArgumentList.Add("--application-path");
-                startInfo.ArgumentList.Add(remoteApp);
-            }
-            bool useDebugger = Debugger.IsAttached;
+                ConnectionTimeout = 1000
+            });
+            Protocol.ProtocolClient client = new(channel);
             if (useDebugger)
             {
-                startInfo.ArgumentList.Add($"--debug");
+                VisualStudioAttacher.AttachVisualStudioToProcess(process);
             }
 
-            if (Process.Start(startInfo) is Process process)
-            {
-                NamedPipeChannel channel = new(".", Server.PipePrefix + process.Id, new NamedPipeChannelOptions
-                {
-                    ConnectionTimeout = 1000
-                });
-                Protocol.ProtocolClient client = new(channel);
-                if (useDebugger)
-                {
-                    VisualStudioAttacher.AttachVisualStudioToProcess(process);
-                }
-
-                return new ManagedApp(process, client, logMessage);
-            }
-            throw new XAMLTestException("Failed to start remote app");
+            return new ManagedApp(process, client, logMessage);
         }
+        throw new XAMLTestException("Failed to start remote app");
     }
 }


### PR DESCRIPTION
Fixes #64
Allows a flag to disable debugger attach, even when a debugger is attached to the host process.