### PR TITLE
Fix issue with app startup failing

### DIFF
--- a/XAMLTest.TestApp/MainWindow.xaml.cs
+++ b/XAMLTest.TestApp/MainWindow.xaml.cs
@@ -1,15 +1,16 @@
-﻿using System.Windows;
+﻿using System;
+using System.Windows;
 
-namespace XAMLTest.TestApp
+namespace XAMLTest.TestApp;
+
+/// <summary>
+/// Interaction logic for MainWindow.xaml
+/// </summary>
+public partial class MainWindow : Window
 {
-    /// <summary>
-    /// Interaction logic for MainWindow.xaml
-    /// </summary>
-    public partial class MainWindow : Window
+    public MainWindow()
     {
-        public MainWindow()
-        {
-            InitializeComponent();
-        }
+        InitializeComponent();
+        Tag = Environment.CommandLine;
     }
 }

--- a/XAMLTest.Tests/AppTests.cs
+++ b/XAMLTest.Tests/AppTests.cs
@@ -1,6 +1,7 @@
 using MaterialDesignThemes.Wpf;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -8,109 +9,124 @@ using XamlTest;
 using XamlTest.Tests.TestControls;
 
 [assembly: GenerateHelpers(typeof(ColorZone))]
-namespace XamlTest.Tests
+namespace XamlTest.Tests;
+
+[TestClass]
+public class AppTests
 {
-    [TestClass]
-    public class AppTests
+    [TestMethod]
+    public async Task OnStartRemote_LaunchesRemoteApp()
     {
-        [TestMethod]
-        public async Task OnStartRemote_LaunchesRemoteApp()
+        await using var app = App.StartRemote<XAMLTest.TestApp.App>();
+        IWindow? window = await app.GetMainWindow();
+        Assert.AreEqual("Test App Window", await window!.GetTitle());
+    }
+
+    [TestMethod]
+    public async Task CanGenerateTypedElement_ForCustomControlInRemoteApp()
+    {
+        await using var app = App.StartRemote<XAMLTest.TestApp.App>();
+        IWindow? window = await app.GetMainWindow();
+        Assert.IsNotNull(window);
+
+        IVisualElement<ColorZone> colorZone = await window.GetElement<ColorZone>("/ColorZone");
+
+        Assert.AreEqual(ColorZoneMode.PrimaryMid, await colorZone.GetMode());
+    }
+
+    [TestMethod]
+    public async Task OnCreateWindow_CanReadTitle()
+    {
+        await using var app = App.StartRemote();
+        await using var recorder = new TestRecorder(app);
+
+        await app.InitializeWithDefaults(Assembly.GetExecutingAssembly().Location);
+        IWindow window = await app.CreateWindowWithContent("", title: "Test Window Title");
+
+        Assert.AreEqual("Test Window Title", await window.GetTitle());
+
+        recorder.Success();
+    }
+
+    [TestMethod]
+    public async Task OnCreateWindow_CanUseCustomWindow()
+    {
+        await using var app = App.StartRemote();
+        await using var recorder = new TestRecorder(app);
+
+        await app.InitializeWithDefaults(Assembly.GetExecutingAssembly().Location);
+
+        IWindow window = await app.CreateWindow<TestWindow>();
+
+        Assert.AreEqual("Custom Test Window", await window.GetTitle());
+
+        recorder.Success();
+    }
+
+    [TestMethod]
+    public async Task OnGetMainWindow_ReturnsNullBeforeWindowCreated()
+    {
+        await using var app = App.StartRemote();
+        await using var recorder = new TestRecorder(app);
+
+        await app.InitializeWithDefaults(Assembly.GetExecutingAssembly().Location);
+
+        IWindow? mainWindow = await app.GetMainWindow();
+
+        Assert.IsNull(mainWindow);
+
+        recorder.Success();
+    }
+
+    [TestMethod]
+    public async Task OnGetMainWindow_AfterMainWindowShownReturnsMainWindow()
+    {
+        await using var app = App.StartRemote();
+        await using var recorder = new TestRecorder(app);
+
+        await app.InitializeWithDefaults(Assembly.GetExecutingAssembly().Location);
+
+        IWindow window1 = await app.CreateWindowWithContent("");
+        IWindow window2 = await app.CreateWindowWithContent("");
+
+        IWindow? mainWindow = await app.GetMainWindow();
+
+        Assert.AreEqual(window1, mainWindow);
+
+        recorder.Success();
+    }
+
+    [TestMethod]
+    public async Task OnGetWindows_ReturnsAllWindows()
+    {
+        await using var app = App.StartRemote();
+        await using var recorder = new TestRecorder(app);
+
+        await app.InitializeWithDefaults(Assembly.GetExecutingAssembly().Location);
+
+        IWindow window1 = await app.CreateWindowWithContent("");
+        IWindow window2 = await app.CreateWindowWithContent("");
+
+        IReadOnlyList<IWindow> windows = await app.GetWindows();
+
+        CollectionAssert.AreEqual(new[] { window1, window2 }, windows.ToArray());
+
+        recorder.Success();
+    }
+
+    [TestMethod]
+    public async Task OnStartWithDebugger_LaunchesWithDebugFlag()
+    {
+        if (!Debugger.IsAttached)
         {
-            await using var app = App.StartRemote<XAMLTest.TestApp.App>();
-            IWindow? window = await app.GetMainWindow();
-            Assert.AreEqual("Test App Window", await window!.GetTitle());
+            Assert.Inconclusive("This test must be run with a debugger attached");
         }
+        await using var app = await App.StartWithDebugger<XAMLTest.TestApp.App>();
+        IWindow? window = await app.GetMainWindow();
 
-        [TestMethod]
-        public async Task CanGenerateTypedElement_ForCustomControlInRemoteApp()
-        {
-            await using var app = App.StartRemote<XAMLTest.TestApp.App>();
-            IWindow? window = await app.GetMainWindow();
-            Assert.IsNotNull(window);
+        Assert.IsNotNull(window);
+        object? tag = await window.GetTag();
 
-            IVisualElement<ColorZone> colorZone = await window.GetElement<ColorZone>("/ColorZone");
-
-            Assert.AreEqual(ColorZoneMode.PrimaryMid, await colorZone.GetMode());
-        }
-
-        [TestMethod]
-        public async Task OnCreateWindow_CanReadTitle()
-        {
-            await using var app = App.StartRemote();
-            await using var recorder = new TestRecorder(app);
-
-            await app.InitializeWithDefaults(Assembly.GetExecutingAssembly().Location);
-            IWindow window = await app.CreateWindowWithContent("", title: "Test Window Title");
-
-            Assert.AreEqual("Test Window Title", await window.GetTitle());
-
-            recorder.Success();
-        }
-
-        [TestMethod]
-        public async Task OnCreateWindow_CanUseCustomWindow()
-        {
-            await using var app = App.StartRemote();
-            await using var recorder = new TestRecorder(app);
-
-            await app.InitializeWithDefaults(Assembly.GetExecutingAssembly().Location);
-
-            IWindow window = await app.CreateWindow<TestWindow>();
-
-            Assert.AreEqual("Custom Test Window", await window.GetTitle());
-
-            recorder.Success();
-        }
-
-        [TestMethod]
-        public async Task OnGetMainWindow_ReturnsNullBeforeWindowCreated()
-        {
-            await using var app = App.StartRemote();
-            await using var recorder = new TestRecorder(app);
-
-            await app.InitializeWithDefaults(Assembly.GetExecutingAssembly().Location);
-
-            IWindow? mainWindow = await app.GetMainWindow();
-
-            Assert.IsNull(mainWindow);
-
-            recorder.Success();
-        }
-
-        [TestMethod]
-        public async Task OnGetMainWindow_AfterMainWindowShownReturnsMainWindow()
-        {
-            await using var app = App.StartRemote();
-            await using var recorder = new TestRecorder(app);
-
-            await app.InitializeWithDefaults(Assembly.GetExecutingAssembly().Location);
-
-            IWindow window1 = await app.CreateWindowWithContent("");
-            IWindow window2 = await app.CreateWindowWithContent("");
-
-            IWindow? mainWindow = await app.GetMainWindow();
-
-            Assert.AreEqual(window1, mainWindow);
-
-            recorder.Success();
-        }
-
-        [TestMethod]
-        public async Task OnGetWindows_ReturnsAllWindows()
-        {
-            await using var app = App.StartRemote();
-            await using var recorder = new TestRecorder(app);
-
-            await app.InitializeWithDefaults(Assembly.GetExecutingAssembly().Location);
-
-            IWindow window1 = await app.CreateWindowWithContent("");
-            IWindow window2 = await app.CreateWindowWithContent("");
-
-            IReadOnlyList<IWindow> windows = await app.GetWindows();
-
-            CollectionAssert.AreEqual(new[] { window1, window2 }, windows.ToArray());
-
-            recorder.Success();
-        }
+        Assert.IsTrue(tag?.ToString()?.Contains("--debug"));
     }
 }

--- a/XAMLTest/App.cs
+++ b/XAMLTest/App.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
+using System.Threading.Tasks;
 using GrpcDotNetNamedPipes;
 using XamlTest.Host;
 using XamlTest.Internal;
@@ -12,18 +13,37 @@ public static class App
 {
     public static IApp StartRemote<TApp>(
         string? xamlTestPath = null,
-        Action<string>? logMessage = null,
-        bool allowDebuggerAttach = true)
+        Action<string>? logMessage = null)
     {
         string location = typeof(TApp).Assembly.Location;
-        return StartRemote(location, xamlTestPath, logMessage, allowDebuggerAttach);
+        return StartRemote(location, xamlTestPath, logMessage);
     }
 
     public static IApp StartRemote(
         string? remoteApp = null,
         string ? xamlTestPath = null,
-        Action<string>? logMessage = null,
-        bool allowDebuggerAttach = true)
+        Action<string>? logMessage = null)
+        => StartRemoteApp(remoteApp, xamlTestPath, logMessage, false).Result;
+
+    public static async Task<IApp> StartWithDebugger<TApp>(
+        string? xamlTestPath = null,
+        Action<string>? logMessage = null)
+    {
+        string location = typeof(TApp).Assembly.Location;
+        return await StartWithDebugger(location, xamlTestPath, logMessage);
+    }
+
+    public static async Task<IApp> StartWithDebugger(
+        string? remoteApp = null,
+        string? xamlTestPath = null,
+        Action<string>? logMessage = null)
+        => await StartRemoteApp(remoteApp, xamlTestPath, logMessage, true);
+
+    private static async Task<IApp> StartRemoteApp(
+        string? remoteApp,
+        string? xamlTestPath,
+        Action<string>? logMessage,
+        bool allowDebuggerAttach)
     {
         xamlTestPath ??= Path.ChangeExtension(Assembly.GetExecutingAssembly().Location, ".exe");
         xamlTestPath = Path.GetFullPath(xamlTestPath);
@@ -58,7 +78,7 @@ public static class App
             Protocol.ProtocolClient client = new(channel);
             if (useDebugger)
             {
-                VisualStudioAttacher.AttachVisualStudioToProcess(process);
+                await VisualStudioAttacher.AttachVisualStudioToProcess(process);
             }
 
             return new ManagedApp(process, client, logMessage);

--- a/XAMLTest/Program.cs
+++ b/XAMLTest/Program.cs
@@ -12,7 +12,7 @@ namespace XamlTest
 {
     internal class Program
     {
-        private static System.Threading.Timer? HeartbeatTimer { get; set; }
+        private static Timer? HeartbeatTimer { get; set; }
 
         [STAThread]
         static int Main(string[] args)

--- a/XAMLTest/Wait.cs
+++ b/XAMLTest/Wait.cs
@@ -2,77 +2,76 @@
 using System.Diagnostics;
 using System.Threading.Tasks;
 
-namespace XamlTest
+namespace XamlTest;
+
+public static class Wait
 {
-    public static class Wait
+    public static async Task For(Func<Task<bool>> action, Retry? retry = null, string? message = null)
     {
-        public static async Task For(Func<Task<bool>> action, Retry? retry = null, string? message = null)
+        if (action is null)
         {
-            if (action is null)
-            {
-                throw new ArgumentNullException(nameof(action));
-            }
-
-            retry ??= Retry.Default;
-
-            int delay = (int)(retry.Timeout.TotalMilliseconds / 10);
-            if (delay < 15)
-            {
-                delay = 0;
-            }
-
-            int numAttempts = 0;
-            var sw = Stopwatch.StartNew();
-            Exception? thrownException = null;
-            do
-            {
-                numAttempts++;
-                try
-                {
-                    if (await action())
-                    {
-                        //Success
-                        return;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    thrownException = ex;
-                }
-                if (delay > 0)
-                {
-                    await Task.Delay(delay);
-                }
-            }
-            while (ShouldRetry());
-            var prefix = message == null ? string.Empty : $"{message}. ";
-            throw new TimeoutException($"{prefix}Timeout of '{retry}' exceeded", thrownException);
-
-            bool ShouldRetry() =>
-                sw.Elapsed <= retry.Timeout ||
-                numAttempts < retry.MinAttempts;
+            throw new ArgumentNullException(nameof(action));
         }
 
-        public static async Task For(Func<Task> action, Retry? retry = null, string? message = null)
+        retry ??= Retry.Default;
+
+        int delay = (int)(retry.Timeout.TotalMilliseconds / 10);
+        if (delay < 15)
         {
-            await For(async () =>
-            {
-                await action();
-                return true;
-            }, retry, message);
+            delay = 0;
         }
 
-        public static async Task<T> For<T>(Func<Task<T>> action, Retry? retry = null, string? message = null)
-            where T : class
+        int numAttempts = 0;
+        var sw = Stopwatch.StartNew();
+        Exception? thrownException = null;
+        do
         {
-            T? rv = default;
-            await For(async () =>
+            numAttempts++;
+            try
             {
-                rv = await action();
-                return true;
-            }, retry, message);
-
-            return rv ?? throw new XAMLTestException("Return value is null");
+                if (await action())
+                {
+                    //Success
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                thrownException = ex;
+            }
+            if (delay > 0)
+            {
+                await Task.Delay(delay);
+            }
         }
+        while (ShouldRetry());
+        var prefix = message == null ? string.Empty : $"{message}. ";
+        throw new TimeoutException($"{prefix}Timeout of '{retry}' exceeded", thrownException);
+
+        bool ShouldRetry() =>
+            sw.Elapsed <= retry.Timeout ||
+            numAttempts < retry.MinAttempts;
+    }
+
+    public static async Task For(Func<Task> action, Retry? retry = null, string? message = null)
+    {
+        await For(async () =>
+        {
+            await action();
+            return true;
+        }, retry, message);
+    }
+
+    public static async Task<T> For<T>(Func<Task<T>> action, Retry? retry = null, string? message = null)
+        where T : class
+    {
+        T? rv = default;
+        await For(async () =>
+        {
+            rv = await action();
+            return true;
+        }, retry, message);
+
+        return rv ?? throw new XAMLTestException("Return value is null");
     }
 }


### PR DESCRIPTION
Attempted fix for #65. This may have been due to a timing issue with the latest VS debugger support. This feature has been moved to a new App.StartWithDebugger method and now supports retry which likely will help.