### PR TITLE
Possible approach to fixing Issue #80 (test failing with scaling applied)

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,11 @@
+<Project>
+	<Target Name="XAMLTest_RemoveDuplicateAnalyzers" BeforeTargets="CoreCompile">
+		<!-- Work around https://github.com/dotnet/wpf/issues/6792 -->
+
+		<ItemGroup>
+			<FilteredAnalyzer Include="@(Analyzer->Distinct())" />
+			<Analyzer Remove="@(Analyzer)" />
+			<Analyzer Include="@(FilteredAnalyzer)" />
+		</ItemGroup>
+	</Target>
+</Project>

--- a/XAMLTest.sln
+++ b/XAMLTest.sln
@@ -1,4 +1,3 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.1.32104.313
@@ -9,6 +8,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
 		.github\workflows\dotnet-core.yml = .github\workflows\dotnet-core.yml
 		global.json = global.json
 		README.md = README.md

--- a/XAMLTest/Host/VisualTreeService.cs
+++ b/XAMLTest/Host/VisualTreeService.cs
@@ -770,12 +770,13 @@ internal partial class VisualTreeService : Protocol.ProtocolBase
         var window = element as Window ?? Window.GetWindow(element);
         Point windowOrigin = window.PointToScreen(new Point(0, 0));
 
+        var scale = GetScalingFromVisual(element);
         Point topLeft = element.TranslatePoint(new Point(0, 0), window);
         Point bottomRight = element.TranslatePoint(new Point(element.ActualWidth, element.ActualHeight), window);
-        double left = windowOrigin.X + topLeft.X;
-        double top = windowOrigin.Y + topLeft.Y;
-        double right = windowOrigin.X + bottomRight.X;
-        double bottom = windowOrigin.Y + bottomRight.Y;
+        double left = windowOrigin.X + topLeft.X * scale.ScaleX;
+        double top = windowOrigin.Y + topLeft.Y * scale.ScaleY;
+        double right = windowOrigin.X + bottomRight.X * scale.ScaleX;
+        double bottom = windowOrigin.Y + bottomRight.Y * scale.ScaleY;
 
         var rvleft = Math.Min(left, right);
         var rvtop = Math.Min(top, bottom);
@@ -783,5 +784,18 @@ internal partial class VisualTreeService : Protocol.ProtocolBase
         var rvbottom = Math.Max(top, bottom);
 
         return new Rect(rvleft, rvtop, rvright - rvleft, rvbottom - rvtop);
+    }
+
+    private static (double ScaleX, double ScaleY) GetScalingFromVisual(Visual visual)
+    {
+        PresentationSource source = PresentationSource.FromVisual(visual);
+        
+        if (source != null)
+        {
+            double scaleX = source.CompositionTarget.TransformToDevice.M11;
+            double scaleY = source.CompositionTarget.TransformToDevice.M22;
+            return (scaleX, scaleY);
+        }
+        return (1.0, 1.0);
     }
 }


### PR DESCRIPTION
Partial fix for #80 
Workaround for #79 

This does not completely fix the issue (#80), it just highlights how to get closer to fixing the issue.

**Important** There may be other areas of the code that suffer from the same issue, which needs a similar type of fix.

With this PR, `VisualTreeService.GetCoordinates()` now extracts the scaling values (x and y) for the monitor on which the provided `FrameworkElement` resides. It then uses these scaling values in the calculations.

With scaling, there will probably always be some rounding errors, and this is also what I am seeing after these changes. With 100% scaling, the `PositionTests.CanClickAtAllPositions` tests all run green, but with 150% some of them still fail. However, now they are only slightly off the expected value; hence the comment about rounding errors.

![image](https://user-images.githubusercontent.com/19572699/179401487-9d2f84df-e3f7-4394-99bc-7fc0e879641b.png)
