### PR TITLE
Fix culture info issues

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,11 @@
+<Project>
+	<Target Name="XAMLTest_RemoveDuplicateAnalyzers" BeforeTargets="CoreCompile">
+		<!-- Work around https://github.com/dotnet/wpf/issues/6792 -->
+
+		<ItemGroup>
+			<FilteredAnalyzer Include="@(Analyzer->Distinct())" />
+			<Analyzer Remove="@(Analyzer)" />
+			<Analyzer Include="@(FilteredAnalyzer)" />
+		</ItemGroup>
+	</Target>
+</Project>

--- a/XAMLTest.sln
+++ b/XAMLTest.sln
@@ -1,4 +1,3 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.1.32104.313
@@ -9,6 +8,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
 		.github\workflows\dotnet-core.yml = .github\workflows\dotnet-core.yml
 		global.json = global.json
 		README.md = README.md

--- a/XAMLTest/Host/VisualTreeService.cs
+++ b/XAMLTest/Host/VisualTreeService.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Imaging;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -268,7 +269,7 @@ internal partial class VisualTreeService : Protocol.ProtocolBase
         {
             if (propertyConverter != null)
             {
-                return propertyConverter.ConvertFromString(request.Value);
+                return propertyConverter.ConvertFromString(null!, CultureInfo.InvariantCulture, request.Value);
             }
             return request.Value;
         }

--- a/XAMLTest/VisualElementMixins.cs
+++ b/XAMLTest/VisualElementMixins.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Media;
@@ -86,7 +87,7 @@ public static partial class VisualElementMixins
 
     private static async Task<T?> SetProperty<T>(IVisualElement element, string propertyName, T value, string? ownerType)
     {
-        IValue newValue = await element.SetProperty(propertyName, value?.ToString() ?? "", typeof(T).AssemblyQualifiedName, ownerType);
+        IValue newValue = await element.SetProperty(propertyName, (value != null ? Convert.ToString(value, CultureInfo.InvariantCulture) : "") ?? "", typeof(T).AssemblyQualifiedName, ownerType);
         if (newValue is { })
         {
             return newValue.GetAs<T?>();


### PR DESCRIPTION
This PR fixes a `CultureInfo` issue.

Since I am in Denmark, although my Windows language is set to english, I still use the Danish `CultureInfo` when it comes to decimals and dates (meaning for a `double`, the '.' is a thousand separator, and ',' is the decimal separator. For dates we also have the day and moth reversed).

To accommodate for these differences in developer setups, I added `InvariantCulture` for the "property to/from string" conversions.

Potentially there are some culture-specific things elsewhere that need similar changes. One place could be the `IValue.GetAs<T>()` implementations.

Some tests were previously failing on my machine because of this, after these changes all tests now run green locally on my PC; I hope they do that in the pipeline as well.