### PR TITLE
Feature request: Mark validation errors on visual element

### DIFF
--- a/XAMLTest.Tests/VisualElementTests.cs
+++ b/XAMLTest.Tests/VisualElementTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
@@ -309,5 +309,63 @@ public class VisualElementTests
         {
             window.Title = "Test Title";
         }
+    }
+
+    [TestMethod]
+    public async Task MarkInvalid_WhenPropertyIsDependencyObjectWithoutExistingBinding_SetsValidationError()
+    {
+        // Arrange
+        await using TestRecorder recorder = new(App);
+
+        const string expectedErrorMessage = "Custom validation error";
+        await Window.SetXamlContent(@"<TextBox x:Name=""TextBox"" />");
+        IVisualElement<TextBox> textBox = await Window.GetElement<TextBox>("TextBox");
+
+        //Act (set validation)
+        await textBox.MarkInvalid(TextBox.TextProperty, expectedErrorMessage);
+        var result1 = await textBox.GetProperty<bool>(System.Windows.Controls.Validation.HasErrorProperty);
+        var validationError1 = await textBox.GetValidationErrorContent<string>(TextBox.TextProperty);
+
+        //Act (clear validation)
+        await textBox.ClearInvalid(TextBox.TextProperty);
+        var result2 = await textBox.GetProperty<bool>(System.Windows.Controls.Validation.HasErrorProperty);
+        var validationError2 = await textBox.GetValidationErrorContent<string>(TextBox.TextProperty);
+
+        //Assert
+        Assert.AreEqual(true, result1);
+        Assert.AreEqual(expectedErrorMessage, validationError1);
+        Assert.AreEqual(false, result2);
+        Assert.IsNull(validationError2);
+
+        recorder.Success();
+    }
+
+    [TestMethod]
+    public async Task MarkInvalid_WhenPropertyIsDependencyObjectWithExistingBinding_SetsValidationError()
+    {
+        // Arrange
+        await using TestRecorder recorder = new(App);
+
+        const string expectedErrorMessage = "Custom validation error";
+        await Window.SetXamlContent(@"<TextBox x:Name=""TextBox"" Text=""{Binding RelativeSource={RelativeSource Self}, Path=Tag}"" />");
+        IVisualElement<TextBox> textBox = await Window.GetElement<TextBox>("TextBox");
+
+        //Act (set validation)
+        await textBox.MarkInvalid(TextBox.TextProperty, expectedErrorMessage);
+        var result1 = await textBox.GetProperty<bool>(System.Windows.Controls.Validation.HasErrorProperty);
+        var validationError1 = await textBox.GetValidationErrorContent<string>(TextBox.TextProperty);
+
+        //Act (clear validation)
+        await textBox.ClearInvalid(TextBox.TextProperty);
+        var result2 = await textBox.GetProperty<bool>(System.Windows.Controls.Validation.HasErrorProperty);
+        var validationError2 = await textBox.GetValidationErrorContent<string>(TextBox.TextProperty);
+
+        //Assert
+        Assert.AreEqual(true, result1);
+        Assert.AreEqual(expectedErrorMessage, validationError1);
+        Assert.AreEqual(false, result2);
+        Assert.IsNull(validationError2);
+
+        recorder.Success();
     }
 }

--- a/XAMLTest/Host/XamlTestSpec.proto
+++ b/XAMLTest/Host/XamlTestSpec.proto
@@ -30,7 +30,16 @@ service Protocol {
 
   //Sets a property
   rpc SetProperty (SetPropertyRequest) returns (PropertyResult);
+
+  //Marks a property as having a validation error
+  rpc MarkInvalid (MarkInvalidRequest) returns (MarkInvalidResult);
+
+  //Clear a validation error from a property
+  rpc ClearInvalid (ClearInvalidRequest) returns (ClearInvalidResult);
   
+  //Marks a property as having a validation error
+  rpc GetValidationErrorContent (GetValidationErrorContentRequest) returns (GetValidationErrorContentResult);
+
   //Set a property with XAML content
   rpc SetXamlProperty (SetXamlPropertyRequest) returns (ElementResult);
 
@@ -111,6 +120,25 @@ message PropertyResult {
   Element element = 5;
 }
 
+message MarkInvalidResult {
+	repeated string errorMessages = 1;
+	string propertyType = 2;
+	Element element = 3;
+}
+
+message GetValidationErrorContentResult {
+	repeated string errorMessages = 1;
+	string value = 2;
+	string valueType = 3;
+	string propertyType = 4;
+}
+
+message ClearInvalidResult {
+	repeated string errorMessages = 1;
+	string propertyType = 2;
+	Element element = 3;
+}
+
 message EffectiveBackgroundQuery {
   string elementId = 1;
   string toElementId = 2;
@@ -130,6 +158,28 @@ message SetPropertyRequest {
   string value = 3;
   string valueType = 4;
   string ownerType = 5;
+}
+
+message MarkInvalidRequest {
+	string elementId = 1;
+	string name = 2;
+	string validationError = 3;
+	string valueType = 4;
+	string ownerType = 5;
+}
+
+message ClearInvalidRequest {
+	string elementId = 1;
+	string name = 2;
+	string valueType = 3;
+	string ownerType = 4;
+}
+
+message GetValidationErrorContentRequest {
+	string elementId = 1;
+	string name = 2;
+	string valueType = 3;
+	string ownerType = 4;
 }
 
 message XamlNamespace {

--- a/XAMLTest/IVisualElement.cs
+++ b/XAMLTest/IVisualElement.cs
@@ -57,6 +57,34 @@ public interface IVisualElement : IEquatable<IVisualElement>
     Task<IValue> SetProperty(string name, string value, string? valueType, string? ownerType);
 
     /// <summary>
+    /// Marks a property as invalid using an internal (XAMLTest specific) validation rule.
+    /// </summary>
+    /// <param name="name">The name of the property</param>
+    /// <param name="validationError">The validation error to set on the property binding</param>
+    /// <param name="valueType">The assembly qualified type of the value</param>
+    /// <param name="ownerType">The assembly qualified name of the type that owns the property</param>
+    /// <returns></returns>
+    Task<IValue> MarkInvalid(string name, string? validationError, string? valueType, string? ownerType);
+
+    /// <summary>
+    /// Clears validation errors for a property (if any).
+    /// </summary>
+    /// <param name="name">The name of the property</param>
+    /// <param name="valueType">The assembly qualified type of the value</param>
+    /// <param name="ownerType">The assembly qualified name of the type that owns the property</param>
+    /// <returns></returns>
+    Task<IValue> ClearInvalid(string name, string? valueType, string? ownerType);
+
+    /// <summary>
+    /// Gets the validation error content for a property (if any).
+    /// </summary>
+    /// <param name="name">The name of the property</param>
+    /// <param name="valueType">The assembly qualified type of the value</param>
+    /// <param name="ownerType">The assembly qualified name of the type that owns the property</param>
+    /// <returns></returns>
+    Task<IValue> GetValidationErrorContent(string name, string? valueType, string? ownerType);
+
+    /// <summary>
     /// Sets the value of a property by loading XAML content.
     /// </summary>
     /// <param name="propertyName">The name of the property</param>

--- a/XAMLTest/Internal/VisualElement.cs
+++ b/XAMLTest/Internal/VisualElement.cs
@@ -145,6 +145,82 @@ internal class VisualElement<T> : IVisualElement, IVisualElement<T>, IElementId
         throw new XAMLTestException("Failed to receive a reply");
     }
 
+    public async Task<IValue> MarkInvalid(string name, string? validationError, string? valueType, string? ownerType)
+    {
+        MarkInvalidRequest query = new()
+        {
+            ElementId = Id,
+            Name = name,
+            ValidationError = validationError,
+            ValueType = valueType,
+            OwnerType = ownerType ?? ""
+        };
+        LogMessage?.Invoke($"{nameof(MarkInvalid)}({name},{validationError},{valueType},{ownerType})");
+        if (await Client.MarkInvalidAsync(query) is { } reply)
+        {
+            if (reply.ErrorMessages.Any())
+            {
+                throw new XAMLTestException(string.Join(Environment.NewLine, reply.ErrorMessages));
+            }
+            if (reply.PropertyType is { } propertyType)
+            {
+                return new Property(propertyType, "bool", true, null, Context);
+            }
+            throw new XAMLTestException("Property reply does not have a type specified");
+        }
+        throw new XAMLTestException("Failed to receive a reply");
+    }
+
+    public async Task<IValue> ClearInvalid(string name, string? valueType, string? ownerType)
+    {
+        ClearInvalidRequest query = new()
+        {
+            ElementId = Id,
+            Name = name,
+            ValueType = valueType,
+            OwnerType = ownerType ?? ""
+        };
+        LogMessage?.Invoke($"{nameof(ClearInvalid)}({name},{valueType},{ownerType})");
+        if (await Client.ClearInvalidAsync(query) is { } reply)
+        {
+            if (reply.ErrorMessages.Any())
+            {
+                throw new XAMLTestException(string.Join(Environment.NewLine, reply.ErrorMessages));
+            }
+            if (reply.PropertyType is { } propertyType)
+            {
+                return new Property(propertyType, "bool", true, null, Context);
+            }
+            throw new XAMLTestException("Property reply does not have a type specified");
+        }
+        throw new XAMLTestException("Failed to receive a reply");
+    }
+
+    public async Task<IValue> GetValidationErrorContent(string name, string? valueType, string? ownerType)
+    {
+        GetValidationErrorContentRequest query = new()
+        {
+            ElementId = Id,
+            Name = name,
+            ValueType = valueType,
+            OwnerType = ownerType ?? ""
+        };
+        LogMessage?.Invoke($"{nameof(GetValidationErrorContent)}({name},{valueType},{ownerType})");
+        if (await Client.GetValidationErrorContentAsync(query) is { } reply)
+        {
+            if (reply.ErrorMessages.Any())
+            {
+                throw new XAMLTestException(string.Join(Environment.NewLine, reply.ErrorMessages));
+            }
+            if (reply.PropertyType is { } propertyType)
+            {
+                return new Property(propertyType, "string", reply.Value, null, Context);
+            }
+            throw new XAMLTestException("Property reply does not have a type specified");
+        }
+        throw new XAMLTestException("Failed to receive a reply");
+    }
+
     public Task<IVisualElement> SetXamlProperty(string propertyName, XamlSegment xaml)
         => SetXamlProperty(propertyName, xaml, null);
 

--- a/XAMLTest/VisualElementMixins.cs
+++ b/XAMLTest/VisualElementMixins.cs
@@ -94,4 +94,60 @@ public static partial class VisualElementMixins
         }
         return default;
     }
+
+    public static async Task<bool> MarkInvalid(this IVisualElement element, DependencyProperty dependencyProperty, string validationError)
+    {
+        if (element is null)
+        {
+            throw new ArgumentNullException(nameof(element));
+        }
+
+        if (dependencyProperty is null)
+        {
+            throw new ArgumentNullException(nameof(dependencyProperty));
+        }
+
+        IValue result = await element.MarkInvalid(dependencyProperty.Name, validationError, typeof(bool).AssemblyQualifiedName, dependencyProperty.OwnerType.AssemblyQualifiedName);
+        if (result is { })
+        {
+            return true;
+        }
+        return false;
+    }
+
+    public static async Task<bool> ClearInvalid(this IVisualElement element, DependencyProperty dependencyProperty)
+    {
+        if (element is null)
+        {
+            throw new ArgumentNullException(nameof(element));
+        }
+
+        if (dependencyProperty is null)
+        {
+            throw new ArgumentNullException(nameof(dependencyProperty));
+        }
+
+        IValue result = await element.ClearInvalid(dependencyProperty.Name, typeof(bool).AssemblyQualifiedName, dependencyProperty.OwnerType.AssemblyQualifiedName);
+        if (result is { })
+        {
+            return true;
+        }
+        return false;
+    }
+
+    public static async Task<T?> GetValidationErrorContent<T>(this IVisualElement element, DependencyProperty dependencyProperty)
+    {
+        if (element is null)
+        {
+            throw new ArgumentNullException(nameof(element));
+        }
+
+        if (dependencyProperty is null)
+        {
+            throw new ArgumentNullException(nameof(dependencyProperty));
+        }
+
+        IValue result = await element.GetValidationErrorContent(dependencyProperty.Name, typeof(T).AssemblyQualifiedName, dependencyProperty.OwnerType.AssemblyQualifiedName);
+        return result.GetAs<T?>();
+    }
 }


### PR DESCRIPTION
This PR is not production ready, it is more a proof-of-concept for a feature request.

The feature request originates from [my PR](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/pull/2805) in the MaterialDesignInXaml project. See the last paragraph regarding the TODOs left in the UI tests.

**Idea**
When writing a unit test for a control in isolation (as opposed to a test for some UI _using_ the control), it would be cool to be able to force a validation error in order to assert that some conditions are met when a validation error is present. Ideally this could be done using the XAMLTest library instead of having to wire up a real `ValidationRule` on a binding in the XAML under test, and also having to "force" the UI into a state where the validation error occurs. All that is - IMO - simply boiler-plate code that I would rather not write in my UI tests.

**Proposed solution**
Extend the XAMLTest library with `MarkInvalid(DP, string)`, `ClearInvalid(DP)`, and `GetValidationErrorContent(DP)` which can be used to bring an element into an "error state" (i.e. `Validation.HasError = true`), clear the "error state" from an element, and get the error content from an element respectively.

I must admit I do not have years of experience with the built-in validation scheme, so there may be some quirks/drawbacks to this approach that I am missing.

I have added some tests as well to illustrate the potential use for this. 