### PR TITLE
Make all unit tests run under 100% and 150% scaling

### DIFF
--- a/XAMLTest.Tests/PositionTests.cs
+++ b/XAMLTest.Tests/PositionTests.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using System.Windows.Controls;
@@ -55,7 +57,17 @@ public class PositionTests
     {
         await UserControl.LeftClick(position);
 
-        string? clickPositon = await PositionTextElement.GetText();
-        Assert.AreEqual(expectedValue, clickPositon);
+        string? clickPosition = await PositionTextElement.GetText();
+        Assert.IsNotNull(clickPosition);
+        AssertAreEqual(expectedValue, clickPosition);
+    }
+
+    private static void AssertAreEqual(string expectedValue, string actualValue, int allowedDeviation = 1) // When 8K monitors become a standard, the allowedDeviation may need to increase slightly.
+    {
+        var expectedValues = expectedValue.Split('x').Select(v => Convert.ToInt32(v)).ToList();
+        var actualValues = actualValue.Split('x').Select(v => Convert.ToInt32(v)).ToList();
+
+        Assert.IsTrue(Math.Abs(expectedValues[0] - actualValues[0]) <= allowedDeviation, $"X value deviates too much. Expected '{expectedValues[0]}' (allowedDeviation={allowedDeviation}), but got '{actualValues[0]}'");
+        Assert.IsTrue(Math.Abs(expectedValues[1] - actualValues[1]) <= allowedDeviation, $"Y value deviates too much. Expected '{expectedValues[1]}' (allowedDeviation={allowedDeviation}), but got '{actualValues[1]}'");
     }
 }

--- a/XAMLTest.Tests/SendMouseInputTests.cs
+++ b/XAMLTest.Tests/SendMouseInputTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
@@ -85,7 +85,7 @@ public class SendMouseInputTests
     [TestMethod]
     public async Task LeftClick_WithPositionOffset_OffsetsCursor()
     {
-        Rect coordinates = await TopMenuItem.GetCoordinates();
+        Rect coordinates = await TopMenuItem.GetCoordinatesRespectScaling();
         Point mousePosition = await TopMenuItem.LeftClick(Position.BottomLeft, 15, -5);
 
         Point expected = coordinates.BottomLeft + new Vector(15, -5);
@@ -117,7 +117,7 @@ public class SendMouseInputTests
     {
         const double tollerance = 1.0;
 
-        Rect coordinates = await Grid.GetCoordinates();
+        Rect coordinates = await Grid.GetCoordinatesRespectScaling();
         Point center = new(
             coordinates.Left + coordinates.Width / 2.0,
             coordinates.Top + coordinates.Height / 2.0);
@@ -148,7 +148,7 @@ public class SendMouseInputTests
     {
         const double tollerance = 1.0;
 
-        Rect coordinates = await Grid.GetCoordinates();
+        Rect coordinates = await Grid.GetCoordinatesRespectScaling();
         Point center = new(
             coordinates.Left + coordinates.Width / 2.0,
             coordinates.Top + coordinates.Height / 2.0);
@@ -163,7 +163,7 @@ public class SendMouseInputTests
     {
         const double tollerance = 1.0;
 
-        Rect coordinates = await Grid.GetCoordinates();
+        Rect coordinates = await Grid.GetCoordinatesRespectScaling();
         Point center = new(
             coordinates.Left + coordinates.Width / 2.0,
             coordinates.Top + coordinates.Height / 2.0);

--- a/XAMLTest/Host/VisualTreeService.Input.cs
+++ b/XAMLTest/Host/VisualTreeService.Input.cs
@@ -83,7 +83,7 @@ partial class VisualTreeService
                             case MouseData.Types.MouseEvent.MoveToElement:
                                 if (element is FrameworkElement frameworkElement)
                                 {
-                                    Rect coordinates = GetCoordinates(frameworkElement);
+                                    Rect coordinates = GetCoordinates(frameworkElement, true);
                                     Position position = Position.Center;
                                     if (!string.IsNullOrEmpty(mouseData.Value))
                                     {

--- a/XAMLTest/Host/VisualTreeService.cs
+++ b/XAMLTest/Host/VisualTreeService.cs
@@ -418,7 +418,7 @@ internal partial class VisualTreeService : Protocol.ProtocolBase
 
             if (dependencyObject is FrameworkElement element)
             {
-                Rect rect = GetCoordinates(element);
+                Rect rect = GetCoordinates(element, request.ApplyScaling);
 
                 reply.Left = rect.Left;
                 reply.Top = rect.Top;
@@ -767,7 +767,7 @@ internal partial class VisualTreeService : Protocol.ProtocolBase
         }
     }
 
-    private static Rect GetCoordinates(FrameworkElement element)
+    private static Rect GetCoordinates(FrameworkElement element, bool applyScaling = false)
     {
         if (element is null)
         {
@@ -777,7 +777,7 @@ internal partial class VisualTreeService : Protocol.ProtocolBase
         var window = element as Window ?? Window.GetWindow(element);
         Point windowOrigin = window.PointToScreen(new Point(0, 0));
 
-        var scale = GetScalingFromVisual(element);
+        var scale = applyScaling ? GetScalingFromVisual(element) : (1,1);
         Point topLeft = element.TranslatePoint(new Point(0, 0), window);
         Point bottomRight = element.TranslatePoint(new Point(element.ActualWidth, element.ActualHeight), window);
         double left = windowOrigin.X + topLeft.X * scale.ScaleX;

--- a/XAMLTest/Host/XamlTestSpec.proto
+++ b/XAMLTest/Host/XamlTestSpec.proto
@@ -159,6 +159,7 @@ message ResourceResult {
 
 message CoordinatesQuery {
   string elementId = 1;
+  bool applyScaling = 2;
 }
 
 message CoordinatesResult {

--- a/XAMLTest/IVisualElement.cs
+++ b/XAMLTest/IVisualElement.cs
@@ -77,8 +77,13 @@ public interface IVisualElement : IEquatable<IVisualElement>
     /// <summary>
     /// Gets the coordinates of the element in screen coordinates.
     /// </summary>
-    /// <returns>Teh smallest bounding rectangle encompasing the element in screen coordinates.</returns>
+    /// <returns>The smallest bounding rectangle encompassing the element in screen coordinates.</returns>
     Task<Rect> GetCoordinates();
+    /// <summary>
+    /// Gets the coordinates of the element in screen coordinates while respecting the DPI scaling applied on the monitor on which the test runs.
+    /// </summary>
+    /// <returns>The smallest bounding rectangle encompassing the element in screen coordinates.</returns>
+    Task<Rect> GetCoordinatesRespectScaling();
 
     Task<IEventRegistration> RegisterForEvent(string name);
     Task UnregisterEvent(IEventRegistration eventRegistration);

--- a/XAMLTest/Internal/VisualElement.cs
+++ b/XAMLTest/Internal/VisualElement.cs
@@ -241,11 +241,22 @@ internal class VisualElement<T> : IVisualElement, IVisualElement<T>, IElementId
         throw new XAMLTestException("Failed to receive a reply");
     }
 
-    public async Task<Rect> GetCoordinates()
+    public Task<Rect> GetCoordinates()
+    {
+        return GetCoordinates(false);
+    }
+
+    public Task<Rect> GetCoordinatesRespectScaling()
+    {
+        return GetCoordinates(true);
+    }
+
+    private async Task<Rect> GetCoordinates(bool applyScaling)
     {
         CoordinatesQuery query = new()
         {
-            ElementId = Id
+            ElementId = Id,
+            ApplyScaling = applyScaling
         };
         LogMessage?.Invoke($"{nameof(GetCoordinates)}()");
         if (await Client.GetCoordinatesAsync(query) is { } reply)


### PR DESCRIPTION
Fix for #80

This makes the mouse positioning tests lenient towards the rounding errors with (150%) scaling.

I opted to extend the API with a `IVisualElement.GetCoordinatesRespectScaling()` method which is useful for tests that grab the coordinates and then assert some mouse interaction against those coordinates (e.g. see the `SendMouseInputTests.cs`). You can consider renaming this (or doing it differently) if you have a better name/idea.