### PR TITLE
Add additional ModifierKeys tests

### DIFF
--- a/XAMLTest/Input/KeyboardInput.cs
+++ b/XAMLTest/Input/KeyboardInput.cs
@@ -67,8 +67,6 @@ internal static class KeyboardInput
 
     private static IEnumerable<WindowInput> GetKeyPress(ModifierKeys modifiers)
     {
-        // TODO: The messages returned from this method currently do not do what we expect them to!
-
         IntPtr lParam = new(0x0000_0000);
         if (modifiers == ModifierKeys.None)
         {


### PR DESCRIPTION
I added a couple more tests to "massage" the ModifierKeys implementation, in particular the use of ModifierKeys.Control.

* Added one test testing a copy-paste scenario and
* Added another test doing a tab switch in a TabControl.