### PR TITLE
Bump Microsoft.CodeAnalysis.Common to 5.3.0 to fix package downgrade

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,8 +8,8 @@
     <PackageVersion Include="Grpc.Tools" Version="2.78.0" />
     <PackageVersion Include="GrpcDotNetNamedPipes" Version="3.1.0" />
     <PackageVersion Include="MaterialDesignThemes" Version="5.3.1" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" PrivateAssets="all" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />


### PR DESCRIPTION
Fixes the pipeline failure in #327.

PR #327 bumps `Microsoft.CodeAnalysis.CSharp` from 5.0.0 to 5.3.0, but `Microsoft.CodeAnalysis.Common` was still pinned at 5.0.0. Since `Microsoft.CodeAnalysis.CSharp` 5.3.0 transitively depends on `Microsoft.CodeAnalysis.Common` 5.3.0, this caused an `NU1605` package downgrade error during restore:

```
error NU1605: Detected package downgrade: Microsoft.CodeAnalysis.Common from 5.3.0 to 5.0.0.
  XAMLTest.UnitTestGenerator -> Microsoft.CodeAnalysis.CSharp 5.3.0 -> Microsoft.CodeAnalysis.Common (= 5.3.0)
  XAMLTest.UnitTestGenerator -> Microsoft.CodeAnalysis.Common (>= 5.0.0)
```

**Fix:** Bump `Microsoft.CodeAnalysis.Common` from 5.0.0 to 5.3.0 in `Directory.Packages.props` to match the transitive dependency.