### PR TITLE
Optimize visual tree queries and serialization performance

### DIFF
--- a/XAMLTest/Host/VisualTreeService.Elements.cs
+++ b/XAMLTest/Host/VisualTreeService.Elements.cs
@@ -10,6 +10,15 @@ namespace XamlTest.Host;
 
 internal partial class VisualTreeService : Protocol.ProtocolBase
 {
+    [GeneratedRegex(@"(?<=^\[[^=\]]+=[^=\]]+)\]")]
+    private static partial Regex PropertyExpressionRegex();
+
+    [GeneratedRegex(@"(?<=.)[\.\/\~]")]
+    private static partial Regex QuerySeparatorRegex();
+
+    [GeneratedRegex(@"\[(?<Index>\d+)]$")]
+    private static partial Regex IndexerRegex();
+
     private Dictionary<string, WeakReference<DependencyObject>> KnownElements { get; } = new();
 
     public override async Task<ElementResult> GetElement(ElementQuery request, ServerCallContext context)
@@ -133,17 +142,14 @@ internal partial class VisualTreeService : Protocol.ProtocolBase
 
         static QueryPartType GetNextQueryType(ref string query, out string value)
         {
-            Regex propertyExpressionRegex = new(@"(?<=^\[[^=\]]+=[^=\]]+)\]");
-            Regex regex = new(@"(?<=.)[\.\/\~]");
-
             string currentQuery = query;
-            if (propertyExpressionRegex.Match(query) is { } propertyExpressionMatch &&
+            if (PropertyExpressionRegex().Match(query) is { } propertyExpressionMatch &&
                 propertyExpressionMatch.Success)
             {
                 currentQuery = query[..(propertyExpressionMatch.Index + 1)];
                 query = query[(propertyExpressionMatch.Index + 1)..];
             }
-            else if (regex.Match(query) is { } match &&
+            else if (QuerySeparatorRegex().Match(query) is { } match &&
                 match.Success)
             {
                 currentQuery = query[..match.Index];
@@ -203,10 +209,8 @@ internal partial class VisualTreeService : Protocol.ProtocolBase
 
         static bool TryEvaluateChildTypeQuery(DependencyObject root, string childTypeQuery, [NotNullWhen(true)] out object? found)
         {
-            Regex indexerRegex = new(@"\[(?<Index>\d+)]$");
-
             int index = 0;
-            Match match = indexerRegex.Match(childTypeQuery);
+            Match match = IndexerRegex().Match(childTypeQuery);
             if (match.Success)
             {
                 index = int.Parse(match.Groups["Index"].Value);

--- a/XAMLTest/Internal/Serializer.cs
+++ b/XAMLTest/Internal/Serializer.cs
@@ -27,9 +27,12 @@ internal class Serializer : ISerializer
 
     string ISerializer.Serialize(Type type, object? value, ISerializer rootSerializer)
     {
-        if (Serializers.FirstOrDefault(x => x.CanSerialize(type, rootSerializer)) is { } serializer)
+        for (int i = 0; i < Serializers.Count; i++)
         {
-            return serializer.Serialize(type, value, rootSerializer);
+            if (Serializers[i].CanSerialize(type, rootSerializer))
+            {
+                return Serializers[i].Serialize(type, value, rootSerializer);
+            }
         }
         return "";
     }
@@ -39,9 +42,12 @@ internal class Serializer : ISerializer
 
     object? ISerializer.Deserialize(Type type, string value, ISerializer rootSerializer)
     {
-        if (Serializers.FirstOrDefault(x => x.CanSerialize(type, rootSerializer)) is { } serializer)
+        for (int i = 0; i < Serializers.Count; i++)
         {
-            return serializer.Deserialize(type, value, rootSerializer);
+            if (Serializers[i].CanSerialize(type, rootSerializer))
+            {
+                return Serializers[i].Deserialize(type, value, rootSerializer);
+            }
         }
         return null;
     }
@@ -55,6 +61,15 @@ internal class Serializer : ISerializer
         return default;
     }
 
-    bool ISerializer.CanSerialize(Type type, ISerializer rootSerializer) 
-        => Serializers.Any(x => x.CanSerialize(type, rootSerializer));
+    bool ISerializer.CanSerialize(Type type, ISerializer rootSerializer)
+    {
+        for (int i = 0; i < Serializers.Count; i++)
+        {
+            if (Serializers[i].CanSerialize(type, rootSerializer))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
Improve regex performance by using `[GeneratedRegex]` for compile-time compilation.
Replace LINQ `FirstOrDefault` calls with explicit `for` loops in the serializer for better lookup efficiency.
