### PR TITLE
Add env var to disable minimize-all behavior

### DIFF
--- a/XAMLTest/App.cs
+++ b/XAMLTest/App.cs
@@ -5,6 +5,8 @@ namespace XamlTest;
 
 public static class App
 {
+    private const string DisableMinimizeAllEnvironmentVariable = "XAMLTEST_DISABLE_MINIMIZEALL";
+
     public static Task<IApp> StartRemote<TApp>(Action<string>? logMessage = null)
     {
         AppOptions options = new()
@@ -31,7 +33,7 @@ public static class App
             throw new XamlTestException($"Could not find test app '{options.XamlTestPath}'");
         }
 
-        if (options.MinimizeOtherWindows)
+        if (options.MinimizeOtherWindows && !IsMinimizeAllDisabled())
         {
             MinimizeOtherWindows();
         }
@@ -127,5 +129,11 @@ public static class App
                     Windows.Win32.UI.WindowsAndMessaging.SHOW_WINDOW_CMD.SW_MINIMIZE);
             }
         }
+    }
+
+    private static bool IsMinimizeAllDisabled()
+    {
+        string? environmentValue = Environment.GetEnvironmentVariable(DisableMinimizeAllEnvironmentVariable);
+        return string.Equals(environmentValue, bool.TrueString, StringComparison.OrdinalIgnoreCase);
     }
 }


### PR DESCRIPTION
Minimizing all open windows during `App.StartRemote` can be disruptive in local development and CI environments. This change adds an opt-out switch so callers can disable that behavior without changing existing app options.

`App.StartRemote` now checks `XAMLTEST_DISABLE_MINIMIZEALL` before calling `MinimizeOtherWindows()`. The minimize-all step is skipped only when the variable is set to `true` (case-insensitive); all other values preserve the current behavior.