### PR TITLE
Add scoped resource locks for cross-process input coordination

### DIFF
--- a/XAMLTest.Tests/ResourceLockTests.cs
+++ b/XAMLTest.Tests/ResourceLockTests.cs
@@ -1,0 +1,47 @@
+using SimulatedApp = XamlTest.Tests.Simulators.App;
+
+namespace XamlTest.Tests;
+
+[TestClass]
+[DoNotParallelize]
+public class ResourceLockTests
+{
+    [TestMethod]
+    public async Task AcquireResourceLocksAsync_WithNone_ReturnsNoOpLock()
+    {
+        await using var app = new SimulatedApp();
+        await using var _ = await app.AcquireResourceLocksAsync(ResourceLocks.None);
+    }
+
+    [TestMethod]
+    public async Task AcquireResourceLocksAsync_WithHeldLock_ThrowsTimeoutException()
+    {
+        await using var app = new SimulatedApp();
+        await using var _ = await app.AcquireResourceLocksAsync(ResourceLocks.Keyboard);
+
+        await Assert.ThrowsExactlyAsync<TimeoutException>(async () =>
+        {
+            await using var lock2 = await app.AcquireResourceLocksAsync(ResourceLocks.Keyboard, TimeSpan.FromMilliseconds(100));
+        });
+    }
+
+    [TestMethod]
+    public async Task AcquireResourceLocksAsync_CanAcquireComposedFlags()
+    {
+        await using var app = new SimulatedApp();
+        await using var _ = await app.AcquireResourceLocksAsync(ResourceLocks.Input | ResourceLocks.Focus, TimeSpan.FromSeconds(1));
+    }
+
+    [TestMethod]
+    public async Task AcquireResourceLocksAsync_UsesDefaultTimeoutWhenTimeoutNotSet()
+    {
+        await using var app = new SimulatedApp();
+        await using var _ = await app.AcquireResourceLocksAsync(ResourceLocks.Mouse, TimeSpan.FromSeconds(1));
+        using CancellationTokenSource cts = new(TimeSpan.FromMilliseconds(100));
+
+        await Assert.ThrowsExactlyAsync<OperationCanceledException>(async () =>
+        {
+            await using var lock2 = await app.AcquireResourceLocksAsync(ResourceLocks.Mouse, cancellationToken: cts.Token);
+        });
+    }
+}

--- a/XAMLTest/AppMixins.ResourceLocks.cs
+++ b/XAMLTest/AppMixins.ResourceLocks.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics;
-
 namespace XamlTest;
 
 public static partial class AppMixins
@@ -18,37 +16,22 @@ public static partial class AppMixins
         return ResourceLockLease.Acquire(locks, timeout ?? ResourceLockSettings.DefaultTimeout, cancellationToken);
     }
 
-    private sealed class ResourceLockLease : IAsyncDisposable
+    private sealed class ResourceLockLease(IReadOnlyList<SemaphoreSlim> acquiredSemaphores) : IAsyncDisposable
     {
-        private static IAsyncDisposable Empty { get; } = new ResourceLockLease();
+        private IReadOnlyList<SemaphoreSlim>? AcquiredSemaphores { get; set; } = acquiredSemaphores;
 
-        private static IReadOnlyList<(ResourceLocks Lock, string Name)> OrderedLocks { get; } =
+        private static IAsyncDisposable Empty { get; } = new ResourceLockLease([]);
+
+        private static IReadOnlyList<ResourceLocks> OrderedLocks { get; } =
         [
-            (ResourceLocks.Keyboard, @"Local\XamlTest.ResourceLocks.Keyboard"),
-            (ResourceLocks.Mouse, @"Local\XamlTest.ResourceLocks.Mouse"),
-            (ResourceLocks.Focus, @"Local\XamlTest.ResourceLocks.Focus")
+            ResourceLocks.Keyboard,
+            ResourceLocks.Mouse,
+            ResourceLocks.Focus
         ];
 
-        private readonly ManualResetEventSlim _releaseSignal = new(false);
-        private readonly TaskCompletionSource _acquired = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        private readonly TaskCompletionSource _released = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        private int _disposeSignaled;
-
-        private ResourceLockLease()
-        {
-            _acquired.SetResult();
-            _released.SetResult();
-        }
-
-        private ResourceLockLease(IReadOnlyList<string> lockNames, TimeSpan timeout, CancellationToken cancellationToken)
-        {
-            Thread ownerThread = new(() => AcquireAndHoldLocks(lockNames, timeout, cancellationToken))
-            {
-                IsBackground = true,
-                Name = "XamlTest.ResourceLockLease"
-            };
-            ownerThread.Start();
-        }
+        private static SemaphoreSlim KeyboardSemaphore { get; } = new(1, 1);
+        private static SemaphoreSlim MouseSemaphore { get; } = new(1, 1);
+        private static SemaphoreSlim FocusSemaphore { get; } = new(1, 1);
 
         public static async ValueTask<IAsyncDisposable> Acquire(
             ResourceLocks requestedLocks,
@@ -66,91 +49,40 @@ public static partial class AppMixins
                 return Empty;
             }
 
-            ResourceLockLease lease = new(locks, timeout, cancellationToken);
-            await lease._acquired.Task.ConfigureAwait(false);
-            return lease;
-        }
-
-        private void AcquireAndHoldLocks(IReadOnlyList<string> lockNames, TimeSpan timeout, CancellationToken cancellationToken)
-        {
-            List<Mutex> acquiredMutexes = new(lockNames.Count);
-            Stopwatch elapsed = Stopwatch.StartNew();
+            List<SemaphoreSlim> acquiredSemaphores = new(locks.Count);
             try
             {
-                foreach (var lockName in lockNames)
+                foreach (var requestedLock in locks)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    TimeSpan remaining = GetRemainingTimeout(timeout, elapsed);
-                    Mutex mutex = new(false, lockName);
-                    if (!Wait(mutex, remaining, cancellationToken))
+                    SemaphoreSlim semaphore = GetSemaphore(requestedLock);
+                    if (!await semaphore.WaitAsync(timeout, cancellationToken).ConfigureAwait(false))
                     {
-                        mutex.Dispose();
-                        throw new TimeoutException($"Failed to acquire resource lock '{lockName}' within {timeout}.");
+                        throw new TimeoutException($"Failed to acquire resource lock '{requestedLock}' within {timeout}.");
                     }
 
-                    acquiredMutexes.Add(mutex);
+                    acquiredSemaphores.Add(semaphore);
                 }
+            }
+            catch
+            {
+                ReleaseAll(acquiredSemaphores);
+                throw;
+            }
 
-                _acquired.SetResult();
-                _releaseSignal.Wait();
-            }
-            catch (Exception ex)
-            {
-                _acquired.TrySetException(ex);
-            }
-            finally
-            {
-                ReleaseAll(acquiredMutexes);
-                _released.TrySetResult();
-            }
-        }
+            return new ResourceLockLease(acquiredSemaphores);
 
-        private static bool Wait(Mutex mutex, TimeSpan timeout, CancellationToken cancellationToken)
-        {
-            if (!cancellationToken.CanBeCanceled)
+            static void ReleaseAll(IReadOnlyList<SemaphoreSlim> acquiredSemaphores)
             {
-                try
+                for (int i = acquiredSemaphores.Count - 1; i >= 0; i--)
                 {
-                    return mutex.WaitOne(timeout);
-                }
-                catch (AbandonedMutexException)
-                {
-                    return true;
+                    acquiredSemaphores[i].Release();
                 }
             }
-
-            int waitResult;
-            try
-            {
-                waitResult = WaitHandle.WaitAny([mutex, cancellationToken.WaitHandle], timeout);
-            }
-            catch (AbandonedMutexException ex) when (ex.MutexIndex == 0)
-            {
-                return true;
-            }
-
-            return waitResult switch
-            {
-                WaitHandle.WaitTimeout => false,
-                0 => true,
-                1 => throw new OperationCanceledException(cancellationToken),
-                _ => throw new InvalidOperationException($"Unexpected wait result '{waitResult}'.")
-            };
         }
 
-        private static TimeSpan GetRemainingTimeout(TimeSpan timeout, Stopwatch elapsed)
-        {
-            if (timeout == Timeout.InfiniteTimeSpan)
-            {
-                return timeout;
-            }
-
-            TimeSpan remaining = timeout - elapsed.Elapsed;
-            return remaining > TimeSpan.Zero ? remaining : TimeSpan.Zero;
-        }
-
-        private static IReadOnlyList<string> GetRequestedLocks(ResourceLocks requestedLocks)
+        private static IReadOnlyList<ResourceLocks> GetRequestedLocks(ResourceLocks requestedLocks)
         {
             ResourceLocks supportedLocks = ResourceLocks.All;
             ResourceLocks invalidFlags = requestedLocks & ~supportedLocks;
@@ -160,29 +92,34 @@ public static partial class AppMixins
             }
 
             return OrderedLocks
-                .Where(x => requestedLocks.HasFlag(x.Lock))
-                .Select(x => x.Name)
+                .Where(x => requestedLocks.HasFlag(x))
                 .ToList();
         }
 
+        private static SemaphoreSlim GetSemaphore(ResourceLocks requestedLock)
+            => requestedLock switch
+            {
+                ResourceLocks.Keyboard => KeyboardSemaphore,
+                ResourceLocks.Mouse => MouseSemaphore,
+                ResourceLocks.Focus => FocusSemaphore,
+                _ => throw new ArgumentOutOfRangeException(nameof(requestedLock), requestedLock, "Unsupported lock.")
+            };
+
         public ValueTask DisposeAsync()
         {
-            if (Interlocked.Exchange(ref _disposeSignaled, 1) == 0)
+            if (AcquiredSemaphores is { } acquiredSemaphores)
             {
-                _releaseSignal.Set();
-                return new ValueTask(_released.Task);
+                AcquiredSemaphores = null;
+                ReleaseAll(acquiredSemaphores);
             }
-
             return ValueTask.CompletedTask;
-        }
 
-        private static void ReleaseAll(IReadOnlyList<Mutex> acquiredMutexes)
-        {
-            for (int i = acquiredMutexes.Count - 1; i >= 0; i--)
+            static void ReleaseAll(IReadOnlyList<SemaphoreSlim> acquiredSemaphores)
             {
-                Mutex mutex = acquiredMutexes[i];
-                mutex.ReleaseMutex();
-                mutex.Dispose();
+                for (int i = acquiredSemaphores.Count - 1; i >= 0; i--)
+                {
+                    acquiredSemaphores[i].Release();
+                }
             }
         }
     }

--- a/XAMLTest/AppMixins.ResourceLocks.cs
+++ b/XAMLTest/AppMixins.ResourceLocks.cs
@@ -1,0 +1,189 @@
+using System.Diagnostics;
+
+namespace XamlTest;
+
+public static partial class AppMixins
+{
+    public static ValueTask<IAsyncDisposable> AcquireResourceLocksAsync(
+        this IApp app,
+        ResourceLocks locks,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (app is null)
+        {
+            throw new ArgumentNullException(nameof(app));
+        }
+
+        return ResourceLockLease.Acquire(locks, timeout ?? ResourceLockSettings.DefaultTimeout, cancellationToken);
+    }
+
+    private sealed class ResourceLockLease : IAsyncDisposable
+    {
+        private static IAsyncDisposable Empty { get; } = new ResourceLockLease();
+
+        private static IReadOnlyList<(ResourceLocks Lock, string Name)> OrderedLocks { get; } =
+        [
+            (ResourceLocks.Keyboard, @"Local\XamlTest.ResourceLocks.Keyboard"),
+            (ResourceLocks.Mouse, @"Local\XamlTest.ResourceLocks.Mouse"),
+            (ResourceLocks.Focus, @"Local\XamlTest.ResourceLocks.Focus")
+        ];
+
+        private readonly ManualResetEventSlim _releaseSignal = new(false);
+        private readonly TaskCompletionSource _acquired = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _released = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _disposeSignaled;
+
+        private ResourceLockLease()
+        {
+            _acquired.SetResult();
+            _released.SetResult();
+        }
+
+        private ResourceLockLease(IReadOnlyList<string> lockNames, TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            Thread ownerThread = new(() => AcquireAndHoldLocks(lockNames, timeout, cancellationToken))
+            {
+                IsBackground = true,
+                Name = "XamlTest.ResourceLockLease"
+            };
+            ownerThread.Start();
+        }
+
+        public static async ValueTask<IAsyncDisposable> Acquire(
+            ResourceLocks requestedLocks,
+            TimeSpan timeout,
+            CancellationToken cancellationToken)
+        {
+            if (timeout < TimeSpan.Zero && timeout != Timeout.InfiniteTimeSpan)
+            {
+                throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "Timeout must be non-negative or Timeout.InfiniteTimeSpan.");
+            }
+
+            var locks = GetRequestedLocks(requestedLocks);
+            if (locks.Count == 0)
+            {
+                return Empty;
+            }
+
+            ResourceLockLease lease = new(locks, timeout, cancellationToken);
+            await lease._acquired.Task.ConfigureAwait(false);
+            return lease;
+        }
+
+        private void AcquireAndHoldLocks(IReadOnlyList<string> lockNames, TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            List<Mutex> acquiredMutexes = new(lockNames.Count);
+            Stopwatch elapsed = Stopwatch.StartNew();
+            try
+            {
+                foreach (var lockName in lockNames)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    TimeSpan remaining = GetRemainingTimeout(timeout, elapsed);
+                    Mutex mutex = new(false, lockName);
+                    if (!Wait(mutex, remaining, cancellationToken))
+                    {
+                        mutex.Dispose();
+                        throw new TimeoutException($"Failed to acquire resource lock '{lockName}' within {timeout}.");
+                    }
+
+                    acquiredMutexes.Add(mutex);
+                }
+
+                _acquired.SetResult();
+                _releaseSignal.Wait();
+            }
+            catch (Exception ex)
+            {
+                _acquired.TrySetException(ex);
+            }
+            finally
+            {
+                ReleaseAll(acquiredMutexes);
+                _released.TrySetResult();
+            }
+        }
+
+        private static bool Wait(Mutex mutex, TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            if (!cancellationToken.CanBeCanceled)
+            {
+                try
+                {
+                    return mutex.WaitOne(timeout);
+                }
+                catch (AbandonedMutexException)
+                {
+                    return true;
+                }
+            }
+
+            int waitResult;
+            try
+            {
+                waitResult = WaitHandle.WaitAny([mutex, cancellationToken.WaitHandle], timeout);
+            }
+            catch (AbandonedMutexException ex) when (ex.MutexIndex == 0)
+            {
+                return true;
+            }
+
+            return waitResult switch
+            {
+                WaitHandle.WaitTimeout => false,
+                0 => true,
+                1 => throw new OperationCanceledException(cancellationToken),
+                _ => throw new InvalidOperationException($"Unexpected wait result '{waitResult}'.")
+            };
+        }
+
+        private static TimeSpan GetRemainingTimeout(TimeSpan timeout, Stopwatch elapsed)
+        {
+            if (timeout == Timeout.InfiniteTimeSpan)
+            {
+                return timeout;
+            }
+
+            TimeSpan remaining = timeout - elapsed.Elapsed;
+            return remaining > TimeSpan.Zero ? remaining : TimeSpan.Zero;
+        }
+
+        private static IReadOnlyList<string> GetRequestedLocks(ResourceLocks requestedLocks)
+        {
+            ResourceLocks supportedLocks = ResourceLocks.All;
+            ResourceLocks invalidFlags = requestedLocks & ~supportedLocks;
+            if (invalidFlags != ResourceLocks.None)
+            {
+                throw new ArgumentOutOfRangeException(nameof(requestedLocks), requestedLocks, $"Unknown resource lock flags '{invalidFlags}'.");
+            }
+
+            return OrderedLocks
+                .Where(x => requestedLocks.HasFlag(x.Lock))
+                .Select(x => x.Name)
+                .ToList();
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref _disposeSignaled, 1) == 0)
+            {
+                _releaseSignal.Set();
+                return new ValueTask(_released.Task);
+            }
+
+            return ValueTask.CompletedTask;
+        }
+
+        private static void ReleaseAll(IReadOnlyList<Mutex> acquiredMutexes)
+        {
+            for (int i = acquiredMutexes.Count - 1; i >= 0; i--)
+            {
+                Mutex mutex = acquiredMutexes[i];
+                mutex.ReleaseMutex();
+                mutex.Dispose();
+            }
+        }
+    }
+}

--- a/XAMLTest/ResourceLockSettings.cs
+++ b/XAMLTest/ResourceLockSettings.cs
@@ -1,0 +1,24 @@
+using System.Diagnostics;
+
+namespace XamlTest;
+
+public static class ResourceLockSettings
+{
+    private static TimeSpan _defaultTimeout = Debugger.IsAttached
+        ? TimeSpan.FromMinutes(10)
+        : TimeSpan.FromSeconds(60);
+
+    public static TimeSpan DefaultTimeout
+    {
+        get => _defaultTimeout;
+        set
+        {
+            if (value < TimeSpan.Zero && value != Timeout.InfiniteTimeSpan)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), value, "Default timeout must be non-negative or Timeout.InfiniteTimeSpan.");
+            }
+
+            _defaultTimeout = value;
+        }
+    }
+}

--- a/XAMLTest/ResourceLocks.cs
+++ b/XAMLTest/ResourceLocks.cs
@@ -1,0 +1,13 @@
+namespace XamlTest;
+
+[Flags]
+public enum ResourceLocks
+{
+    None = 0,
+    Keyboard = 1 << 0,
+    Mouse = 1 << 1,
+    Focus = 1 << 2,
+
+    Input = Keyboard | Mouse,
+    All = Keyboard | Mouse | Focus
+}


### PR DESCRIPTION
Parallel test sessions can interfere with each other when they use keyboard, mouse, or focus-sensitive interactions. This adds a scoped locking API so tests can coordinate access to shared UI input resources without exposing low-level synchronization primitives.

## What changed
- Added a flagged `ResourceLocks` enum (`Keyboard`, `Mouse`, `Focus`, plus `Input` and `All`).
- Added `AcquireResourceLocksAsync(...)` on `IApp` mixins for `await using` scoped lock usage.
- Implemented lock acquisition with named system mutexes to coordinate across processes, not just threads.
- Added deterministic lock ordering and reverse release to avoid deadlocks.
- Added `ResourceLockSettings.DefaultTimeout` as a public configurable default timeout.
  - Defaults to 60 seconds.
  - Defaults to 10 minutes when a debugger is attached.
- Added targeted tests for no-op locking, contention timeout behavior, composed flags, and default-timeout behavior.

## Notes for reviewers
- The locking mechanism is intentionally kept internal so consumers stay on the XAMLTest API surface.
- Timeout can be overridden per call or globally through `ResourceLockSettings.DefaultTimeout`.