### PR TITLE
ci: Enable OIDC-based authentication for NuGet publishing

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -23,6 +23,11 @@ env:
 
 jobs:
   build:
+    # Required for Trusted Publishing: allows GitHub to issue OIDC tokens for this job
+    # This enables secure, keyless authentication with NuGet.org
+    permissions:
+      id-token: write
+
     runs-on: windows-latest
 
     steps:
@@ -96,9 +101,16 @@ jobs:
         name: NuGet
         path: ${{ github.workspace }}\XAMLTest\bin\${{ env.configuration }}\XAMLTest.${{ env.nugetVersion }}*nupkg
 
+    - name: NuGet login (OIDC → temporary API key)
+      if: ${{ github.event_name != 'pull_request' }}
+      uses: NuGet/login@v1
+      id: login
+      with:
+        user: ${{ secrets.NUGET_USER }} 
+
     - name: Push NuGet
       if: ${{ github.event_name != 'pull_request' }}
-      run: dotnet nuget push ${{ github.workspace }}\XAMLTest\bin\${{ env.configuration }}\XAMLTest.${{ env.nugetVersion }}.nupkg --source https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+      run: dotnet nuget push ${{ github.workspace }}\XAMLTest\bin\${{ env.configuration }}\XAMLTest.${{ env.nugetVersion }}.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --skip-duplicate
       
   automerge:
     needs: build


### PR DESCRIPTION
This change configures Trusted Publishing to use OpenID Connect (OIDC) for NuGet package deployment from the CI pipeline. By leveraging GitHub's OIDC capabilities, the workflow can now authenticate with NuGet.org using temporary tokens, removing the dependency on a long-lived NuGet API key and improving overall security.
